### PR TITLE
Added support of ansible lint 4 version

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -119,7 +119,7 @@ function validateAnsibleFile(document: TextDocument): void {
 
 	child.stdout.on("data", (data: Buffer) => {
 		let tmp = data.toString();
-		const lint_regex = /(.*):(\d+).*ANSIBLE\d{4}\]\s(.*)/;
+		const lint_regex = /(.*):(\d+).*[ANSIBL]*E\d{3,4}\]\s(.*)/;
 		tmp.split(/\r?\n/).forEach(function (line) {
 
 			const lint_matches = lint_regex.exec(line);


### PR DESCRIPTION
Ansible lint pep8 parsible output format has been changed. Instead [ANSIBLE0000] now it looks like [E000].
This fix adds support both main versions (3.4, 4)